### PR TITLE
Introduce `get_message` on JSException

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ In general, this version strips down the WASMEdge QuickJS implementation to allo
   - Enables functions like `setTimeout`, `setImmediate`.
   - Enables http support and socket support, among others that require IO access granted by the preview1 WASI snapshot.
 - Added `inherit_env` feature. Disabled by default for security. If enabled, the process env of the `Context`-instantiating Rust code will be passed down to executed JS.
+- Added `get_message` on `JsException` to get the error message of the exception if it follows a common JS error structure.
 
 ## Prerequisites
 

--- a/examples/embed_js/src/main.rs
+++ b/examples/embed_js/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
 fn js_hello(ctx: &mut Context) {
     println!("\n<----run_simple_js---->");
     let code = r#"print('hello quickjs')"#;
-    let r = ctx.eval_global_str(code);
+    let r = ctx.eval_global_str(code, true);
     println!("return value:{:?}", r);
 }
 
@@ -25,7 +25,7 @@ fn run_js_code(ctx: &mut Context) {
     print('js print: 1+1=',a);
     'hello'; // eval_return
     "#;
-    let r = ctx.eval_global_str(code);
+    let r = ctx.eval_global_str(code, true);
     println!("return value:{:?}", r);
 }
 
@@ -36,7 +36,7 @@ fn run_js_function(ctx: &mut Context) {
         print("js print: x=",x)
     }
     "#;
-    let r = ctx.eval_global_str(code);
+    let r = ctx.eval_global_str(code, true);
     println!("return value:{:?}", r);
     if let JsValue::Function(f) = r {
         let hello_str = ctx.new_string("hello");
@@ -53,7 +53,7 @@ fn run_js_function(ctx: &mut Context) {
         return old_value
     }
     "#;
-    let r = ctx.eval_global_str(code);
+    let r = ctx.eval_global_str(code, true);
     if let JsValue::Function(f) = r {
         let mut x = ctx.new_array();
         x.set(0, 0.into());
@@ -81,7 +81,7 @@ fn run_rust_function(ctx: &mut Context) {
     let f = ctx.new_function::<HelloFn>("hello");
     ctx.get_global().set("hi", f.into());
     let code = r#"hi(1,2,3)"#;
-    let r = ctx.eval_global_str(code);
+    let r = ctx.eval_global_str(code, true);
     println!("return value:{:?}", r);
 }
 
@@ -116,7 +116,7 @@ fn rust_new_object_and_js_call(ctx: &mut Context) {
     test_obj.f(1,2,3,"hi")
     "#;
 
-    ctx.eval_global_str(code);
+    ctx.eval_global_str(code, true);
 }
 
 fn js_new_object_and_rust_call(ctx: &mut Context) {
@@ -133,7 +133,7 @@ fn js_new_object_and_rust_call(ctx: &mut Context) {
     }
     obj
     "#;
-    if let JsValue::Object(mut obj) = ctx.eval_global_str(code) {
+    if let JsValue::Object(mut obj) = ctx.eval_global_str(code, true) {
         let mut args = vec![ctx.new_string("rust_args_string").into()];
 
         let obj_map = obj.to_map();
@@ -167,7 +167,7 @@ fn js_promise(ctx: &mut Context) {
     f
     "#;
 
-    let r = ctx.eval_global_str(code);
+    let r = ctx.eval_global_str(code, true);
     println!("{:?}", r);
     if let JsValue::Function(f) = r {
         let mut args = vec![];

--- a/examples/embed_js_module/src/main.rs
+++ b/examples/embed_js_module/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     })
     "#;
 
-    let p = ctx.eval_global_str(code);
+    let p = ctx.eval_global_str(code, true);
     println!("before poll:{:?}", p);
     if let JsValue::Promise(ref p) = p {
         let v = p.get_result();

--- a/examples/embed_rust_module/src/main.rs
+++ b/examples/embed_rust_module/src/main.rs
@@ -111,6 +111,6 @@ fn main() {
     })
     "#;
 
-    ctx.eval_global_str(code);
+    ctx.eval_global_str(code, true);
     ctx.promise_loop_poll();
 }

--- a/examples/embed_use_es6_module/src/main.rs
+++ b/examples/embed_use_es6_module/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     m
     "#;
 
-    let p = ctx.eval_global_str(code);
+    let p = ctx.eval_global_str(code, true);
     println!("before poll:{:?}", p);
     ctx.promise_loop_poll();
     println!("after poll:{:?}", p);

--- a/examples/host_function/src/main.rs
+++ b/examples/host_function/src/main.rs
@@ -27,5 +27,5 @@ fn main() {
     let mut ctx = Context::new();
     let f = ctx.new_function::<host_extern::HostIncFn>("host_inc");
     ctx.get_global().set("host_inc", f.into());
-    ctx.eval_global_str("print('js=> host_inc(2)=',host_inc(2))");
+    ctx.eval_global_str("print('js=> host_inc(2)=',host_inc(2))", true);
 }

--- a/examples/js_extend.rs
+++ b/examples/js_extend.rs
@@ -157,6 +157,6 @@ fn main() {
 
         print('b instanceof ClassA =',b instanceof ClassA)
         "#;
-        ctx.eval_global_str(code.to_string());
+        ctx.eval_global_str(code.to_string(), true);
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ fn args_parse() -> (String, Vec<String>) {
 
 fn main() {
     use wasmedge_quickjs as q;
+
+   test_errors();
+
     let mut rt = q::Runtime::new();
     rt.run_with_context(|ctx| {
         let (file_path, mut rest_arg) = args_parse();
@@ -36,5 +39,45 @@ fn main() {
             }
         }
         ctx.js_loop().unwrap();
+    });
+}
+
+fn test_errors() {
+    use wasmedge_quickjs as q;
+
+    let mut rt = q::Runtime::new();
+    rt.run_with_context(|ctx| {
+        let code = String::from("const x = {};x.hello.world;");
+        let r = ctx.eval_global_str(code, false);
+        match r {
+            JsValue::Exception(exception) => {
+                println!("Exception value:{:?}", exception.get_message());
+            }
+            _ => {
+                println!("return value:{:?}", r);
+            }
+        }
+
+        let code = String::from("throw new Error('x.hello');");
+        let r = ctx.eval_global_str(code, false);
+        match r {
+            JsValue::Exception(exception) => {
+                println!("Exception value:{:?}", exception.get_message());
+            }
+            _ => {
+                println!("return value:{:?}", r);
+            }
+        }
+
+        let code = String::from("throw 6;");
+        let r = ctx.eval_global_str(code, false);
+        match r {
+            JsValue::Exception(exception) => {
+                println!("Exception value:{:?}", exception.get_message());
+            }
+            _ => {
+                println!("return value:{:?}", r);
+            }
+        }
     });
 }


### PR DESCRIPTION
We want to be able to convey the error_messages in our logging