### PR TITLE
ensure we are freeing memory on succesful invocations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,4 +80,20 @@ fn test_errors() {
             }
         }
     });
+
+    let mut rt = q::Runtime::new();
+    rt.run_with_context(|ctx| {
+        let code = String::from("(() => {
+            return { crazy: 'shit here my friend' };
+        })()");
+        let r = ctx.eval_global_str(code, false);
+        match r {
+            JsValue::Exception(exception) => {
+                println!("Exception value:{:?}", exception.get_message());
+            }
+            _ => {
+                println!("return value:{:?}", r);
+            }
+        }
+    });
 }

--- a/src/quickjs_sys/mod.rs
+++ b/src/quickjs_sys/mod.rs
@@ -409,12 +409,16 @@ impl Context {
                     eval_flags as i32,
                 )
             };
-            if dump_error && JS_IsException_real(val) > 0 {
-                js_std_dump_error(ctx);
-            } else {
-                let str = JS_ToString(ctx, val);
-                return JsValue::from_qjs_value(ctx, str);
+
+            if JS_IsException_real(val) > 0  {
+                if dump_error {
+                    js_std_dump_error(ctx);
+                } else {
+                    let str = JS_ToString(ctx, val);
+                    return JsValue::from_qjs_value(ctx, str);
+                }
             }
+
             JsValue::from_qjs_value(ctx, val)
         }
     }


### PR DESCRIPTION
When we successfully run a JSFunction we would run into the branch of not dumping the error without an exception, which meant we created a pointer that would never get cleaned up.