### PR TITLE
add base64 funcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +646,7 @@ name = "wasmedge_quickjs"
 version = "0.4.0-alpha"
 dependencies = [
  "argparse",
+ "base64",
  "encoding",
  "image",
  "imageproc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 
 [dependencies]
 argparse = "0.2.2"
+base64 = "0.21.5"
 image = { version = "0.23.6", default-features = false, features = ["jpeg", "png"], optional = true }
 imageproc = { version =  "0.22.0", optional = true }
 libc = "0.2"

--- a/src/internal_module/base64.rs
+++ b/src/internal_module/base64.rs
@@ -9,14 +9,17 @@ fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
       Some(JsValue::String(base64_string)) => Some(base64_string),
       // For correctness we would need to convert any number, undefined or null to 
       // a string but not sure if we can coerce here.
-      Some(value) => value.to_string(),
+      Some(_value) => {
+        ctx.throw_type_error("atob needs a string-argument to be passed");
+        return JsValue::UnDefined;
+      }
       None => {
-        ctx.throw_type_error("Could not decode to UTF-8 String");
+        ctx.throw_type_error("atob needs an argument to be passed");
         return JsValue::UnDefined;
       }
     };
-    if let Some(JsValue::String(base64_string)) = base64_string {
-      let result = general_purpose::STANDARD_NO_PAD.decode(base64_string.to_string());
+    if let Some(base64_string) = base64_string {
+      let result = general_purpose::STANDARD.decode(base64_string.to_string());
       match result {
         Ok(decoded) => {
           let result = String::from_utf8(decoded);
@@ -25,13 +28,13 @@ fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
               let js_string = ctx.new_string(final_decoded_string.as_str());
               JsValue::String(js_string)
             }
-            Err(e) => {
+            Err(_e) => {
               ctx.throw_type_error("Could not decode to UTF-8 String");
               JsValue::UnDefined
             }
           }
         }
-        Err(e) => {
+        Err(_e) => {
             ctx.throw_type_error("Could not decode to UTF-8 String");
             JsValue::UnDefined
         }
@@ -44,11 +47,12 @@ fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
 fn btoa(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
     let raw_string = argv.get(0);
     if let Some(JsValue::String(raw_string)) = raw_string {
-      let encoded_string = general_purpose::STANDARD_NO_PAD.encode(raw_string.to_string());
+      let encoded_string = general_purpose::STANDARD.encode(raw_string.to_string());
       let js_string = ctx.new_string(encoded_string.as_str());
       JsValue::String(js_string)
     } else {
-      JsValue::UnDefined
+      ctx.throw_type_error("atob needs a string argument to be passed");
+      return JsValue::UnDefined;
     }
 }
 

--- a/src/internal_module/base64.rs
+++ b/src/internal_module/base64.rs
@@ -1,80 +1,76 @@
-extern crate base64;
-use base64::{Engine as _, engine::general_purpose};
-
-use crate::{JsValue, Context, JsString};
 use crate::quickjs_sys::*;
+use crate::{Context, JsString, JsValue};
+use base64::{engine::general_purpose, Engine as _};
 
 fn coerce_to_string(ctx: &mut Context, js_value: &JsValue) -> Option<JsString> {
-  match js_value {
-    JsValue::String(value) => Some(value.to_owned()),
-    JsValue::Int(number) => Some(ctx.new_string(number.to_string().as_str())),
-    JsValue::Bool(bool) => Some(ctx.new_string(bool.to_string().as_str())),
-    JsValue::Float(float) => Some(ctx.new_string(float.to_string().as_str())),
-    JsValue::UnDefined => Some(ctx.new_string("undefined")),
-    JsValue::Null => Some(ctx.new_string("null")),
-    _ => None
-  }
+    match js_value {
+        JsValue::String(value) => Some(value.to_owned()),
+        JsValue::Int(number) => Some(ctx.new_string(number.to_string().as_str())),
+        JsValue::Bool(bool) => Some(ctx.new_string(bool.to_string().as_str())),
+        JsValue::Float(float) => Some(ctx.new_string(float.to_string().as_str())),
+        JsValue::UnDefined => Some(ctx.new_string("undefined")),
+        JsValue::Null => Some(ctx.new_string("null")),
+        _ => None,
+    }
 }
 
 fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
     let base64_string = match argv.get(0) {
-      Some(JsValue::String(base64_string)) => base64_string.to_owned(),
-      _ => {
-        ctx.throw_type_error("atob needs an argument to be passed");
-        return JsValue::UnDefined;
-      }
+        Some(JsValue::String(base64_string)) => base64_string.as_str(),
+        _ => {
+            ctx.throw_type_error("atob needs an argument to be passed");
+            return JsValue::UnDefined;
+        }
     };
 
-    let result = general_purpose::STANDARD.decode(base64_string.to_string());
+    let result = general_purpose::STANDARD.decode(base64_string);
     match result {
-      Ok(decoded) => {
-        let result = String::from_utf8(decoded);
-        match result {
-          Ok(final_decoded_string) => {
-            let js_string = ctx.new_string(final_decoded_string.as_str());
-            JsValue::String(js_string)
-          }
-          Err(_e) => {
+        Ok(decoded) => {
+            let result = String::from_utf8(decoded);
+            match result {
+                Ok(final_decoded_string) => {
+                    let js_string = ctx.new_string(&final_decoded_string);
+                    JsValue::String(js_string)
+                }
+                Err(_e) => {
+                    ctx.throw_type_error("Could not decode to UTF-8 String");
+                    JsValue::UnDefined
+                }
+            }
+        }
+
+        Err(_e) => {
             ctx.throw_type_error("Could not decode to UTF-8 String");
             JsValue::UnDefined
-          }
         }
-      }
-      Err(_e) => {
-          ctx.throw_type_error("Could not decode to UTF-8 String");
-          JsValue::UnDefined
-      }
     }
 }
 
 fn btoa(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
-  let raw_string = match argv.get(0) {
-    Some(JsValue::String(base64_string)) => base64_string.to_owned(),
-    // For correctness we would need to convert any number, undefined or null to 
-    // a string but not sure if we can coerce here.
-    Some(value) => {
-      let result = coerce_to_string(ctx, value);
-      if let Some(result) = result {
-        result
-      } else {
-        ctx.throw_type_error("btoa needs a string-argument to be passed");
-        return JsValue::UnDefined;
-      }
-    }
-    None => {
-      ctx.throw_type_error("btoa needs an argument to be passed");
-      return JsValue::UnDefined;
-    }
-  };
+    let js_string = match argv.get(0) {
+        Some(JsValue::String(base64_string)) => base64_string.to_owned(),
 
-    let encoded_string = general_purpose::STANDARD.encode(raw_string.to_string());
-    let js_string = ctx.new_string(encoded_string.as_str());
-    JsValue::String(js_string)
+        Some(value) => match coerce_to_string(ctx, value) {
+            Some(result) => result,
+            None => {
+                ctx.throw_type_error("btoa needs a string-argument to be passed");
+                return JsValue::UnDefined;
+            }
+        },
+
+        None => {
+            ctx.throw_type_error("btoa needs an argument to be passed");
+            return JsValue::UnDefined;
+        }
+    };
+
+    let encoded_string = general_purpose::STANDARD.encode(js_string.as_str());
+    JsValue::String(ctx.new_string(&encoded_string))
 }
 
 pub fn init_base64_functions(ctx: &mut Context) {
-  let mut global = ctx.get_global();
+    let mut global = ctx.get_global();
 
-  global.set("btoa", ctx.wrap_function("btoa", btoa).into());
-  global.set("atob", ctx.wrap_function("atob", atob).into());
+    global.set("btoa", ctx.wrap_function("btoa", btoa).into());
+    global.set("atob", ctx.wrap_function("atob", atob).into());
 }

--- a/src/internal_module/base64.rs
+++ b/src/internal_module/base64.rs
@@ -4,56 +4,72 @@ use base64::{Engine as _, engine::general_purpose};
 use crate::{JsValue, Context, JsString};
 use crate::quickjs_sys::*;
 
+fn coerce_to_string(ctx: &mut Context, js_value: &JsValue) -> Option<JsString> {
+  match js_value {
+    JsValue::String(value) => Some(value.to_owned()),
+    JsValue::Int(number) => Some(ctx.new_string(number.to_string().as_str())),
+    JsValue::Bool(bool) => Some(ctx.new_string(bool.to_string().as_str())),
+    JsValue::Float(float) => Some(ctx.new_string(float.to_string().as_str())),
+    JsValue::UnDefined => Some(ctx.new_string("undefined")),
+    JsValue::Null => Some(ctx.new_string("null")),
+    _ => None
+  }
+}
+
 fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
     let base64_string = match argv.get(0) {
-      Some(JsValue::String(base64_string)) => Some(base64_string),
-      // For correctness we would need to convert any number, undefined or null to 
-      // a string but not sure if we can coerce here.
-      Some(_value) => {
-        ctx.throw_type_error("atob needs a string-argument to be passed");
-        return JsValue::UnDefined;
-      }
-      None => {
+      Some(JsValue::String(base64_string)) => base64_string.to_owned(),
+      _ => {
         ctx.throw_type_error("atob needs an argument to be passed");
         return JsValue::UnDefined;
       }
     };
-    if let Some(base64_string) = base64_string {
-      let result = general_purpose::STANDARD.decode(base64_string.to_string());
-      match result {
-        Ok(decoded) => {
-          let result = String::from_utf8(decoded);
-          match result {
-            Ok(final_decoded_string) => {
-              let js_string = ctx.new_string(final_decoded_string.as_str());
-              JsValue::String(js_string)
-            }
-            Err(_e) => {
-              ctx.throw_type_error("Could not decode to UTF-8 String");
-              JsValue::UnDefined
-            }
+
+    let result = general_purpose::STANDARD.decode(base64_string.to_string());
+    match result {
+      Ok(decoded) => {
+        let result = String::from_utf8(decoded);
+        match result {
+          Ok(final_decoded_string) => {
+            let js_string = ctx.new_string(final_decoded_string.as_str());
+            JsValue::String(js_string)
           }
-        }
-        Err(_e) => {
+          Err(_e) => {
             ctx.throw_type_error("Could not decode to UTF-8 String");
             JsValue::UnDefined
+          }
         }
       }
-    } else {
-        JsValue::UnDefined
+      Err(_e) => {
+          ctx.throw_type_error("Could not decode to UTF-8 String");
+          JsValue::UnDefined
+      }
     }
 }
 
 fn btoa(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
-    let raw_string = argv.get(0);
-    if let Some(JsValue::String(raw_string)) = raw_string {
-      let encoded_string = general_purpose::STANDARD.encode(raw_string.to_string());
-      let js_string = ctx.new_string(encoded_string.as_str());
-      JsValue::String(js_string)
-    } else {
-      ctx.throw_type_error("atob needs a string argument to be passed");
+  let raw_string = match argv.get(0) {
+    Some(JsValue::String(base64_string)) => base64_string.to_owned(),
+    // For correctness we would need to convert any number, undefined or null to 
+    // a string but not sure if we can coerce here.
+    Some(value) => {
+      let result = coerce_to_string(ctx, value);
+      if let Some(result) = result {
+        result
+      } else {
+        ctx.throw_type_error("btoa needs a string-argument to be passed");
+        return JsValue::UnDefined;
+      }
+    }
+    None => {
+      ctx.throw_type_error("btoa needs an argument to be passed");
       return JsValue::UnDefined;
     }
+  };
+
+    let encoded_string = general_purpose::STANDARD.encode(raw_string.to_string());
+    let js_string = ctx.new_string(encoded_string.as_str());
+    JsValue::String(js_string)
 }
 
 pub fn init_base64_functions(ctx: &mut Context) {

--- a/src/internal_module/base64.rs
+++ b/src/internal_module/base64.rs
@@ -1,0 +1,46 @@
+extern crate base64;
+use base64::{Engine as _, engine::general_purpose};
+
+use crate::{JsValue, Context, JsString};
+use crate::quickjs_sys::*;
+
+fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
+    let base64_string = argv.get(0);
+    if let Some(JsValue::String(base64_string)) = base64_string {
+      let result = general_purpose::STANDARD_NO_PAD.decode(base64_string.into());
+      if let Ok(decoded) = result {
+        let result = String::from_utf8(decoded);
+        if let Ok(final_decoded_string) = result {
+          // TODO: needs to become JsString
+          JsValue::String(final_decoded_string.into())
+        } else {
+          JsValue::UnDefined
+        }
+      } else {
+        JsValue::UnDefined
+      }
+    } else {
+        JsValue::UnDefined
+    }
+}
+
+fn btoa(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
+    let raw_string = argv.get(0);
+    if let Some(JsValue::String(raw_string)) = raw_string {
+      let result = general_purpose::STANDARD_NO_PAD.encode(raw_string.into());
+      if let Ok(encoded) = result {
+        JsValue::String(encoded)
+      } else {
+        JsValue::UnDefined
+      }
+    } else {
+        JsValue::UnDefined
+    }
+}
+
+pub fn init_base64_functions(ctx: &mut Context) {
+  let mut global = ctx.get_global();
+
+  global.set("btoa", ctx.wrap_function("btoa", btoa).into());
+  global.set("atob", ctx.wrap_function("atob", atob).into());
+}

--- a/src/internal_module/base64.rs
+++ b/src/internal_module/base64.rs
@@ -7,12 +7,12 @@ use crate::quickjs_sys::*;
 fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
     let base64_string = argv.get(0);
     if let Some(JsValue::String(base64_string)) = base64_string {
-      let result = general_purpose::STANDARD_NO_PAD.decode(base64_string.into());
+      let result = general_purpose::STANDARD_NO_PAD.decode(base64_string.to_string());
       if let Ok(decoded) = result {
         let result = String::from_utf8(decoded);
         if let Ok(final_decoded_string) = result {
-          // TODO: needs to become JsString
-          JsValue::String(final_decoded_string.into())
+          let js_string = ctx.new_string(final_decoded_string.as_str());
+          JsValue::String(js_string)
         } else {
           JsValue::UnDefined
         }
@@ -27,14 +27,11 @@ fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
 fn btoa(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
     let raw_string = argv.get(0);
     if let Some(JsValue::String(raw_string)) = raw_string {
-      let result = general_purpose::STANDARD_NO_PAD.encode(raw_string.into());
-      if let Ok(encoded) = result {
-        JsValue::String(encoded)
-      } else {
-        JsValue::UnDefined
-      }
+      let encoded_string = general_purpose::STANDARD_NO_PAD.encode(raw_string.to_string());
+      let js_string = ctx.new_string(encoded_string.as_str());
+      JsValue::String(js_string)
     } else {
-        JsValue::UnDefined
+      JsValue::UnDefined
     }
 }
 

--- a/src/internal_module/mod.rs
+++ b/src/internal_module/mod.rs
@@ -1,3 +1,4 @@
+pub mod base64;
 pub mod core;
 pub mod encoding;
 pub mod httpx;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ fn args_parse() -> (String, Vec<String>) {
 fn main() {
     use wasmedge_quickjs as q;
 
+   test_base64();
    test_errors();
 
     let mut rt = q::Runtime::new();
@@ -40,6 +41,60 @@ fn main() {
         }
         ctx.js_loop().unwrap();
     });
+}
+
+fn test_base64() {
+    use wasmedge_quickjs as q;
+    let mut rt = q::Runtime::new();
+    rt.run_with_context(|ctx| {
+        let code = String::from("btoa('stellate')");
+        let r = ctx.eval_global_str(code, false);
+        if let JsValue::String(js_string) = r {
+            if js_string.as_str() == "c3RlbGxhdGU=" {
+                println!("Matched encode value")
+            } else {
+                println!("Missmatched encode value")
+            }
+        } else {
+            println!("Missmatched encode value")
+        }
+
+        let code = String::from("atob('c3RlbGxhdGU=')");
+        let r = ctx.eval_global_str(code, false);
+        if let JsValue::String(js_string) = r {
+            if js_string.as_str() == "stellate" {
+                println!("Matched decode value")
+            } else {
+                println!("Missmatched decode value")
+            }
+        } else {
+            println!("Missmatched decode value")
+        }
+
+        let code = String::from("btoa(undefined)");
+        let r = ctx.eval_global_str(code, false);
+        if let JsValue::String(js_string) = r {
+            if js_string.as_str() == "dW5kZWZpbmVk" {
+                println!("Matched encode value")
+            } else {
+                println!("Missmatched encode value")
+            }
+        } else {
+            println!("Missmatched encode value")
+        }
+
+        let code = String::from("atob('dW5kZWZpbmVk')");
+        let r = ctx.eval_global_str(code, false);
+        if let JsValue::String(js_string) = r {
+            if js_string.as_str() == "undefined" {
+                println!("Matched decode value")
+            } else {
+                println!("Missmatched decode value")
+            }
+        } else {
+            println!("Missmatched decode value")
+        }
+    })
 }
 
 fn test_errors() {

--- a/src/quickjs_sys/mod.rs
+++ b/src/quickjs_sys/mod.rs
@@ -339,6 +339,7 @@ impl Context {
 
         js_init_dirname(&mut ctx);
 
+        super::internal_module::base64::init_base64_functions(&mut ctx);
         super::internal_module::core::init_global_function(&mut ctx);
         super::internal_module::core::init_ext_function(&mut ctx);
         super::internal_module::encoding::init_encoding_module(&mut ctx);


### PR DESCRIPTION
This adds the browser base64 functions `btoa` and `atob` to convert base64. Just going to check whether we have to use `NO_PAD` or a different algo here. Generally this returns undefined when an invalid string is found, I can also convert this to throwing an error which seems safer

Resolve GCDN-3437