### PR TITLE
support no-padded base64 in atob

### DIFF
--- a/src/internal_module/base64.rs
+++ b/src/internal_module/base64.rs
@@ -23,7 +23,9 @@ fn atob(ctx: &mut Context, _this_val: JsValue, argv: &[JsValue]) -> JsValue {
         }
     };
 
-    let result = general_purpose::STANDARD.decode(base64_string);
+    let result = general_purpose::STANDARD
+        .decode(base64_string)
+        .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(base64_string));
     match result {
         Ok(decoded) => {
             let result = String::from_utf8(decoded);


### PR DESCRIPTION
While writing some e2e tests I ran into issues where calling `atob` in a dynamic scope function failed on a JWT payload produced by the popular `jsonwebtoken` NPM package. Turns out it uses no padding. I think the best way to go about this is similar to what we do in fastly-l1, i.e. just try both encoding variants.